### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/testeITO123/7192cef4-aedd-4b8a-8f34-58173f58f625/aa1c4457-f9e3-4df0-9190-7609a2df9051/_apis/work/boardbadge/a24859f8-cc4a-49db-96c9-60531eac985f)](https://dev.azure.com/testeITO123/7192cef4-aedd-4b8a-8f34-58173f58f625/_boards/board/t/aa1c4457-f9e3-4df0-9190-7609a2df9051/Microsoft.RequirementCategory)
 # Hello World 2
 
 Figure out how to work with Desktop GitHub


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/testeITO123/7192cef4-aedd-4b8a-8f34-58173f58f625/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.